### PR TITLE
Implement framework selector for code snippets

### DIFF
--- a/src/lib/generateSnippet.js
+++ b/src/lib/generateSnippet.js
@@ -1,4 +1,4 @@
-// Generates a Svelte snippet string for the SquigglySlider based on current UI state
+// Generates a framework-specific snippet string for the SquigglySlider based on current UI state
 // Pure utility; reads computed styles in browser to resolve CSS variables to hex
 
 function rgbToHex(rgbString) {
@@ -22,7 +22,11 @@ function resolveToHex(input, fallback = '#616118') {
   return fallback;
 }
 
-export function generateSnippet(cfg, importPath = 'squiggly-sliders') {
+function cssEscape(str) {
+  return String(str).replace(/'/g, "\\'");
+}
+
+function generateSvelteSnippet(cfg) {
   const {
     activeColor,
     passiveColor,
@@ -58,6 +62,85 @@ export function generateSnippet(cfg, importPath = 'squiggly-sliders') {
   return lines.join('\n');
 }
 
-function cssEscape(str) {
-  return String(str).replace(/'/g, "\\'");
+function generateReactSnippet(cfg) {
+  const {
+    activeColor,
+    passiveColor,
+    activeAmplitude,
+    passiveAmplitude,
+    activeWavelength,
+    passiveWavelength,
+    speedFactor,
+    value,
+    min = 0,
+    max = 10,
+    step = 1
+  } = cfg;
+
+  const activeHex = resolveToHex(activeColor, '#616118');
+  const passiveHex = resolveToHex(passiveColor, '#1c1c14');
+
+  const lines = [];
+  lines.push('<SquigglySlider');
+  lines.push(`  min={${min}}`);
+  lines.push(`  max={${max}}`);
+  lines.push(`  value={${value}}`);
+  lines.push(`  active={'${cssEscape(activeHex)}'}`);
+  lines.push(`  passive={'${cssEscape(passiveHex)}'}`);
+  lines.push(`  activeAmplitude={${activeAmplitude}}`);
+  lines.push(`  passiveAmplitude={${passiveAmplitude}}`);
+  lines.push(`  activeWavelength={${activeWavelength}}`);
+  lines.push(`  passiveWavelength={${passiveWavelength}}`);
+  lines.push(`  speedFactor={${speedFactor}}`);
+  if (step !== 1) lines.push(`  step={${step}}`);
+  lines.push('/>');
+
+  return lines.join('\n');
+}
+
+function generateWebComponentSnippet(cfg) {
+  const {
+    activeColor,
+    passiveColor,
+    activeAmplitude,
+    passiveAmplitude,
+    activeWavelength,
+    passiveWavelength,
+    speedFactor,
+    value,
+    min = 0,
+    max = 10,
+    step = 1
+  } = cfg;
+
+  const activeHex = resolveToHex(activeColor, '#616118');
+  const passiveHex = resolveToHex(passiveColor, '#1c1c14');
+
+  const attrs = [];
+  attrs.push(`min="${min}"`);
+  attrs.push(`max="${max}"`);
+  attrs.push(`value="${value}"`);
+  attrs.push(`active="${cssEscape(activeHex)}"`);
+  attrs.push(`passive="${cssEscape(passiveHex)}"`);
+  attrs.push(`active-amplitude="${activeAmplitude}"`);
+  attrs.push(`passive-amplitude="${passiveAmplitude}"`);
+  attrs.push(`active-wavelength="${activeWavelength}"`);
+  attrs.push(`passive-wavelength="${passiveWavelength}"`);
+  attrs.push(`speed-factor="${speedFactor}"`);
+  if (step !== 1) attrs.push(`step="${step}"`);
+
+  return `<squiggly-slider ${attrs.join(' ')}></squiggly-slider>`;
+}
+
+export function generateSnippet(cfg, importPath = 'squiggly-sliders', framework = 'svelte') {
+  switch (framework) {
+    case 'svelte':
+      return generateSvelteSnippet(cfg);
+    case 'react':
+      return generateReactSnippet(cfg);
+    case 'javascript':
+      return generateWebComponentSnippet(cfg);
+    default:
+      return generateSvelteSnippet(cfg);
+  }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script>
     import SquigglySlider from '$lib/squigglySlider.svelte';
     import Button from '../lib/button.svelte';
-    import { fade, slide } from 'svelte/transition';
+    import { fade, scale } from 'svelte/transition';
     import { translateIn, translateOut, fadeSlide } from '$lib/translateIn.js';
     import { backOut, cubicOut, expoOut } from 'svelte/easing';
     import { writable } from 'svelte/store';
@@ -15,10 +15,12 @@
     import hljs from 'highlight.js/lib/core';
     import javascript from 'highlight.js/lib/languages/javascript';
     import xml from 'highlight.js/lib/languages/xml';
+    import jsx from 'highlight.js/lib/languages/jsx';
     
     // Register languages
     hljs.registerLanguage('javascript', javascript);
     hljs.registerLanguage('xml', xml);
+    hljs.registerLanguage('jsx', jsx.default || jsx);
 
     let sliders = [
     ];
@@ -43,6 +45,23 @@
     const minVal = 0;
     const maxVal = 10;
     const stepVal = 1;
+    
+    // Framework selector
+    let framework = 'svelte'; // 'svelte' | 'react' | 'javascript'
+    let instructionsModalVisible = false;
+    
+    // Load framework preference from localStorage
+    if (typeof window !== 'undefined' && window.localStorage) {
+        const savedFramework = localStorage.getItem('squiggly-sliders-framework');
+        if (savedFramework && ['svelte', 'react', 'javascript'].includes(savedFramework)) {
+            framework = savedFramework;
+        }
+    }
+    
+    // Save framework preference to localStorage when it changes
+    $: if (typeof window !== 'undefined' && window.localStorage) {
+        localStorage.setItem('squiggly-sliders-framework', framework);
+    }
 
     $: currentSnippet = generateSnippet({
         activeColor,
@@ -56,7 +75,7 @@
         min: minVal,
         max: maxVal,
         step: stepVal,
-    }, importPath);
+    }, importPath, framework);
 
     onMount(() => {
         controlCentreDown = false;
@@ -82,10 +101,16 @@
     function escapeHtml(s) {
         return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     }
-    function highlightSvelte(code) {
+    function highlightSnippet(code) {
         if (!code) return '';
-        // Use highlight.js to highlight the code
-        const highlighted = hljs.highlight(code, { language: 'xml' }).value;
+        // Use highlight.js to highlight the code based on framework
+        let language = 'xml';
+        if (framework === 'react') {
+            language = 'jsx';
+        } else if (framework === 'javascript') {
+            language = 'xml';
+        }
+        const highlighted = hljs.highlight(code, { language }).value;
         return highlighted;
     }
 
@@ -556,6 +581,24 @@
 
                 <div class="hidden md:flex items-center justify-between">
                     <h2 class="font-extrabold">Preview</h2>
+                    <div class="flex items-center gap-4">
+                        <button 
+                            on:click={() => {instructionsModalVisible = true}} 
+                            class="text-on-surface text-sm font-medium transition-colors duration-200 hover:text-on-surface-variant focus-visible:text-on-surface-variant"
+                            aria-label="Instructions"
+                        >
+                            Instructions
+                        </button>
+                        <select 
+                            bind:value={framework}
+                            class="bg-surface-container-highest text-on-surface text-sm rounded-lg px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+                            aria-label="Select framework for code snippet"
+                        >
+                            <option value="svelte">Svelte</option>
+                            <option value="react">React</option>
+                            <option value="javascript">JavaScript</option>
+                        </select>
+                    </div>
                 </div>
 
                 <div class="flex-auto flex flex-col items-center justify-center relative py-4">
@@ -574,7 +617,7 @@
                     <button on:click={copySnippet} class="absolute top-2 right-2 increment-button rounded-full h-7 w-7 flex items-center justify-center hover:brightness-110 active:scale-95 transition-all" aria-label="Copy code">
                         <div class="material-symbols-rounded text-base">content_copy</div>
                     </button>
-                    <pre class="overflow-auto p-0 text-[13px] leading-5 font-mono"><code class="hljs rounded-xl">{@html highlightSvelte(currentSnippet)}</code></pre>
+                    <pre class="overflow-auto p-0 text-[13px] leading-5 font-mono"><code class="hljs rounded-xl">{@html highlightSnippet(currentSnippet)}</code></pre>
                 </div>
 
                 <div class="flex w-full justify-end">
@@ -705,7 +748,53 @@
     .tok-number{color:#ff9e64}
 </style>
 
-<!-- <input type="text" class="w-full h-12 border border-surface-container-high placeholder:text-outline-variant
-text-sm rounded-lg px-2 bg-surface-container-low font-semibold placeholder:transition-transform overflow-visible placeholder:origin-top-left focus-visible:pt-2 transition-all
-focus-visible:outline-primary focus-visible:placeholder:-translate-y-4 focus-visible:placeholder:scale-75 focus-visible:placeholder:text-primary
-" value="" placeholder="Active Amplitude (6)" /> -->
+
+{#if instructionsModalVisible}
+    <div in:fade={{duration: 300, easing: cubicOut}} out:fade={{duration: 200, easing: cubicOut}} on:click={() => {instructionsModalVisible = false}} class="fixed top-0 left-0 w-full h-full backdrop-blur-lg z-30 bg-[rgba(253,249,236,0.85)] dark:bg-[rgba(20,20,12,.85)]"></div>
+    <div in:scale={{duration: 300, easing: cubicOut}} out:scale={{duration: 200, easing: cubicOut}} class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[calc(100%-2rem)] md:w-108 z-30">
+        <div class="ios-nav-in flex flex-col items-center gap-6 w-full h-full p-2 pt-4 bg-surface-container shadow-lg rounded-2xl">
+            <button on:click={() => {instructionsModalVisible = false}} style="scale: 0;" 
+                class="scale-up animation-delay-50 easing-elastic absolute top-0 right-4 -mt-4 rounded-full button-shadow-default1 border border-dashed border-outline-variant dark:border-outline-variant h-8 w-8 bg-surface-container-high text-outline lg:text-on-surface flex items-center justify-center md:hover:brightness-95 active:brightness-95 md:active:brightness-[.93] active:scale-95 transition-all duration-100 flex-shrink-0">
+                <div class="material-symbols-rounded text-xl font-semibold">close</div>
+            </button>
+            <h1 class="text-2xl font-bold flex-shrink-0 mt-2">Framework Instructions</h1>
+            <div class="px-[10%] flex flex-col gap-4 text-center w-full">
+                {#if framework === 'svelte'}
+                    <div class="text-left">
+                        <h2 class="font-bold text-lg mb-2">Svelte Usage</h2>
+                        <p class="text-sm mb-3">Install the package:</p>
+                        <pre class="bg-surface-container-highest p-3 rounded-lg text-sm mb-3"><code>npm i squiggly-sliders</code></pre>
+                        <p class="text-sm mb-3">Import the component:</p>
+                        <pre class="bg-surface-container-highest p-3 rounded-lg text-sm mb-3"><code>import SquigglySlider from 'squiggly-sliders'</code></pre>
+                        <p class="text-sm">Use the component:</p>
+                    </div>
+                {:else if framework === 'react'}
+                    <div class="text-left">
+                        <h2 class="font-bold text-lg mb-2">React Usage</h2>
+                        <p class="text-sm mb-3">The React component can be found at:</p>
+                        <pre class="bg-surface-container-highest p-3 rounded-lg text-sm mb-3"><code>src/lib/react/SquigglySlider.jsx</code></pre>
+                        <p class="text-xs mb-1"><a href="https://github.com/raayyananan/squiggly-sliders/blob/main/src/lib/react/SquigglySlider.jsx" target="_blank" class="text-primary hover:underline">View on GitHub →</a></p>
+                        <p class="text-sm mb-3">Copy this file into your project and import it locally:</p>
+                        <pre class="bg-surface-container-highest p-3 rounded-lg text-sm mb-3"><code>import SquigglySlider from './SquigglySlider.jsx'</code></pre>
+                        <p class="text-sm">Use the component (note the camelCase props):</p>
+                    </div>
+                {:else if framework === 'javascript'}
+                    <div class="text-left">
+                        <h2 class="font-bold text-lg mb-2">JavaScript/Web Component Usage</h2>
+                        <p class="text-sm mb-3">The Web Component can be found at:</p>
+                        <pre class="bg-surface-container-highest p-3 rounded-lg text-sm mb-3"><code>src/lib/SquigglySlider.js</code></pre>
+                        <p class="text-xs mb-1"><a href="https://github.com/raayyananan/squiggly-sliders/blob/main/src/lib/SquigglySlider.js" target="_blank" class="text-primary hover:underline">View on GitHub →</a></p>
+                        <p class="text-sm mb-3">Or the element implementation:</p>
+                        <pre class="bg-surface-container-highest p-3 rounded-lg text-sm mb-3"><code>src/lib/web/SquigglySliderElement.js</code></pre>
+                        <p class="text-xs mb-1"><a href="https://github.com/raayyananan/squiggly-sliders/blob/main/src/lib/web/SquigglySliderElement.js" target="_blank" class="text-primary hover:underline">View on GitHub →</a></p>
+                        <p class="text-sm mb-3">Copy one of these files into your project and import it, or import it from a built file if published.</p>
+                        <p class="text-sm">Use the component with dash-case attributes:</p>
+                    </div>
+                {/if}
+                <div class="text-left">
+                    <pre class="bg-surface-container-highest p-3 rounded-lg text-sm"><code>{@html highlightSnippet(currentSnippet)}</code></pre>
+                </div>
+            </div>
+        </div>
+    </div>        
+{/if}


### PR DESCRIPTION
Added a framework selector allowing users to choose between Svelte, React, and JavaScript when generating code snippets. Each framework has its own syntax format (curly braces for Svelte/React, dash-case attributes for Web Components) and appropriate syntax highlighting. Also added an instructions modal with framework-specific usage guidance and GitHub links to the implementation files.