### PR TITLE
Set .hljs code block background to bg-inverse-surface

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -271,6 +271,10 @@ button {
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .hljs { @apply bg-inverse-surface; }
+}
+
 
 .easing-emphasized {transition-timing-function: var(--md-sys-motion-easing-emphasized);}
 .easing-accelerate {transition-timing-function: var(--md-sys-motion-easing-emphasized-accelerate);}


### PR DESCRIPTION
This PR sets the background of highlight.js code blocks to the inverse surface color.

Summary
- Apply Tailwind utility to `.hljs` so code blocks get an inverse surface background for better contrast across light/dark themes.
- Implemented via `@layer components { .hljs { @apply bg-inverse-surface; } }` in `src/app.scss`.

Why
- Improves readability of code blocks and aligns with existing theme tokens.
- The repository defines the token as `inverse-surface` (Tailwind class `bg-inverse-surface`), so this PR uses that naming to stay consistent. If you intended `bg-surface-inverse`, please note that token does not exist in this theme and the equivalent here is `bg-inverse-surface`.

Changes
- src/app.scss: add a small Tailwind layer snippet to style `.hljs`.

Impact
- Purely visual (background color for `.hljs` blocks). No runtime logic affected.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/572d6b28-84af-11f0-a94e-3eef481a796b/task/be1d188c-5176-46d0-ba1e-8db7b187c6dd))