### PR TITLE
Preload About dialog images to remove animation jank

### DIFF
--- a/src/lib/preloadImages.js
+++ b/src/lib/preloadImages.js
@@ -1,0 +1,19 @@
+export function preloadImages(sources) {
+  if (!Array.isArray(sources) || sources.length === 0) return Promise.resolve();
+  const unique = Array.from(new Set(sources.filter(Boolean)));
+  const loaders = unique.map((src) =>
+    new Promise((resolve) => {
+      const img = new Image();
+      const done = () => resolve();
+      img.onload = done;
+      img.onerror = done;
+      img.decoding = 'async';
+      img.fetchPriority = 'low';
+      img.src = src;
+      if (img.complete) {
+        resolve();
+      }
+    })
+  );
+  return Promise.all(loaders).then(() => undefined);
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,9 @@
 <script>
+    import { onMount } from "svelte";
     import { fade } from "svelte/transition";
     import "../app.scss";
     // import { Toaster } from "svelte-sonner";
+    import { preloadImages } from "../lib/preloadImages.js";
     let activeColor = '--slider-color-1',
     passiveColor = '--slider-passive-color-2'
     let activePickerOpen = false, passivePickerOpen = false;
@@ -21,6 +23,8 @@
         '--slider-passive-color-3',
         '--slider-passive-color-4',
     ]
+    const imagesToPreload = ['/pin image 1.png', '/pin image 2.png'];
+    onMount(() => { preloadImages(imagesToPreload); });
 </script>
 
 <!-- <Toaster /> -->


### PR DESCRIPTION
## Summary
Preload About dialog screenshots on app startup to eliminate visible loading delay during the modal animation.

## Changes
- Added `src/lib/preloadImages.js`: small Promise-based utility to preload multiple images and resolve when loaded (or error) so it never blocks.
- Updated `src/routes/+layout.svelte` to call `preloadImages(['/pin image 1.png', '/pin image 2.png'])` in `onMount`, ensuring both screenshots are cached early.
- Left `src/lib/modal.svelte` as-is to maintain existing behavior and visuals; it benefits from the cache when opened.

## Why
- The About dialog previously loaded two screenshots on-demand, causing jank as images streamed in during the entrance animation.
- Preloading on layout mount ensures the assets are in cache before the dialog is opened, making the transition smooth and immediate.

## Impact
- No user-facing visual changes; improved perceived performance when opening the About dialog.
- Very small code footprint; no additional dependencies.

## Notes
- If desired, a simple store could be added later to gate the card animation on asset readiness for the rare case when the dialog is opened immediately on page load.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/572d6b28-84af-11f0-a94e-3eef481a796b/task/fe5924c7-093e-411a-b33a-761a7b197405))